### PR TITLE
Add cleaner, non-stacktrace logging for failed auth exception

### DIFF
--- a/src/main/java/com/openlattice/mail/pods/MailServicePod.java
+++ b/src/main/java/com/openlattice/mail/pods/MailServicePod.java
@@ -20,27 +20,18 @@
 
 package com.openlattice.mail.pods;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.kryptnostic.rhizome.configuration.ConfigurationConstants.Profiles;
-import com.kryptnostic.rhizome.configuration.amazon.AmazonLaunchConfiguration;
-import com.kryptnostic.rhizome.configuration.amazon.AwsLaunchConfiguration;
-import com.kryptnostic.rhizome.emails.configuration.MailServiceConfiguration;
-import com.openlattice.ResourceConfigurationLoader;
-import java.io.IOException;
-
-import javax.inject.Inject;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
+import com.kryptnostic.rhizome.configuration.service.ConfigurationService;
 import com.openlattice.mail.config.MailServiceConfig;
 import com.openlattice.mail.config.MailServiceRequirements;
 import com.openlattice.mail.services.MailRenderer;
 import com.openlattice.mail.services.MailService;
-import com.kryptnostic.rhizome.configuration.service.ConfigurationService;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Profile;
+
+import javax.inject.Inject;
+import java.io.IOException;
 
 /**
  * This is the plugin pod that will activate a mail service lambda
@@ -58,6 +49,9 @@ public class MailServicePod {
 
     @Inject
     private MailServiceConfig mailServiceConfig;
+
+    @Inject
+    private ApplicationContext context;
 
     @Bean
     public MailService mailService() throws IOException {

--- a/src/main/java/com/openlattice/mail/services/MailService.java
+++ b/src/main/java/com/openlattice/mail/services/MailService.java
@@ -23,10 +23,9 @@ package com.openlattice.mail.services;
 import com.google.common.base.Preconditions;
 import com.hazelcast.core.IQueue;
 import com.openlattice.mail.RenderableEmailRequest;
-import com.openlattice.mail.config.HtmlEmailTemplate;
 import com.openlattice.mail.config.MailServiceConfig;
-import java.util.Set;
 import jodd.mail.Email;
+import jodd.mail.MailException;
 import jodd.mail.SendMailSession;
 import jodd.mail.SmtpServer;
 import jodd.mail.SmtpSslServer;
@@ -34,6 +33,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
+
+import java.util.Set;
 
 public class MailService {
     private final MailRenderer                   mailRenderer;
@@ -50,7 +51,7 @@ public class MailService {
         this.emailRequests = emailRequests;
         configureSmtpServer( config );
         this.mailRenderer = mailRenderer;
-        logger.info( "Mail Service successfull configured and initialized!" );
+        logger.info( "Mail Service successfully configured and initialized!" );
     }
 
     public void configureSmtpServer( MailServiceConfig config ) {
@@ -66,14 +67,6 @@ public class MailService {
         // TODO: figure out why we get above exception when plaintextOverTLS is false and port is 587 (works for 465)
         // .plaintextOverTLS(false)
         // .startTlsRequired(true);
-    }
-
-    public void upsertTemplate( HtmlEmailTemplate template ) {
-
-    }
-
-    public void deleteTemplate( String templateId ) {
-
     }
 
     protected Set<Email> renderEmail( RenderableEmailRequest emailRequest ) {
@@ -96,7 +89,11 @@ public class MailService {
     @Scheduled( fixedRate = 30000 )
     public void processEmailRequestsQueue() {
         SendMailSession session = smtpServer.createSession();
-        session.open();
+        try {
+            session.open();
+        } catch ( MailException ex ) {
+            logger.error( "Failure opening email session: {}", ex.getMessage());
+        }
 
         while ( !emailRequests.isEmpty() ) {
             RenderableEmailRequest emailRequest = null;


### PR DESCRIPTION
This PR:
- Gets rid of the stacktrace when email auth fails and prints a message instead