### PR TITLE
functionals, warnings, use foreach

### DIFF
--- a/src/main/java/com/openlattice/mail/services/MailRenderer.java
+++ b/src/main/java/com/openlattice/mail/services/MailRenderer.java
@@ -48,12 +48,12 @@ public class MailRenderer {
 
     @VisibleForTesting
     public static boolean isNotBlacklisted( String to ) {
-        return !REGISTRATION_DOMAIN_BLACKLIST.stream().anyMatch( ( domain ) -> to.contains( domain ) );
+        return !REGISTRATION_DOMAIN_BLACKLIST.stream().anyMatch( to::contains );
     }
 
     protected Set<Email> renderEmail( RenderableEmailRequest emailRequest ) {
         Iterable<String> toAddresses = Iterables.filter( Arrays.asList( emailRequest.getTo() ),
-                ( String address ) -> isNotBlacklisted( address ) );
+                MailRenderer::isNotBlacklisted );
         logger.info( "filtered e-mail addresses that are blacklisted." );
 
         if ( Iterables.size( toAddresses ) < 1 ) {
@@ -87,15 +87,15 @@ public class MailRenderer {
                     .htmlMessage( templateHtml );
             if ( emailRequest.getByteArrayAttachment().isPresent() ) {
                 EmailAttachment[] attachments = emailRequest.getByteArrayAttachment().get();
-                for ( int i = 0; i < attachments.length; i++ ) {
-                    email.attachment( attachments[ i ] );
+                for ( EmailAttachment attachment : attachments ) {
+                    email.attachment( attachment );
                 }
             }
 
             if ( emailRequest.getAttachmentPaths().isPresent() ) {
                 String[] paths = emailRequest.getAttachmentPaths().get();
-                for ( int i = 0; i < paths.length; i++ ) {
-                    email.attachment( EmailAttachment.with().content( paths[ i ] ) );
+                for ( String path : paths ) {
+                    email.attachment( EmailAttachment.with().content( path ) );
                 }
             }
 

--- a/src/main/java/com/openlattice/mail/services/MailRenderer.java
+++ b/src/main/java/com/openlattice/mail/services/MailRenderer.java
@@ -20,24 +20,22 @@
 
 package com.openlattice.mail.services;
 
-import com.openlattice.mail.RenderableEmailRequest;
-import com.openlattice.mail.exceptions.InvalidTemplateException;
-import com.openlattice.mail.templates.EmailTemplate;
-import com.openlattice.mail.utils.TemplateUtils;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Set;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
-
+import com.openlattice.mail.RenderableEmailRequest;
+import com.openlattice.mail.exceptions.InvalidTemplateException;
+import com.openlattice.mail.templates.EmailTemplate;
+import com.openlattice.mail.utils.TemplateUtils;
 import jodd.mail.Email;
 import jodd.mail.EmailAttachment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Set;
 
 public class MailRenderer {
     private Logger                   logger                        = LoggerFactory
@@ -70,7 +68,7 @@ public class MailRenderer {
         }
         String templateHtml = TemplateUtils.DEFAULT_TEMPLATE_COMPILER
                 .compile( template )
-                .execute( emailRequest.getTemplateObjs().or( new Object() ) );
+                .execute( emailRequest.getTemplateObjs().orElse( new Object() ) );
 
         /*
          * when someone invites multiple people, we want to spool an individual invite for each person. as such, we need
@@ -81,9 +79,9 @@ public class MailRenderer {
         for ( String toAddress : toAddresses ) {
 
             Email email = Email.create()
-                    .from( emailRequest.getFrom().or( EmailTemplate.getCourierEmailAddress() ) )
+                    .from( emailRequest.getFrom().orElse( EmailTemplate.getCourierEmailAddress() ) )
                     .to( toAddress )
-                    .subject( emailRequest.getSubject().or( "" ) )
+                    .subject( emailRequest.getSubject().orElse( "" ) )
                     .htmlMessage( templateHtml );
             if ( emailRequest.getByteArrayAttachment().isPresent() ) {
                 EmailAttachment[] attachments = emailRequest.getByteArrayAttachment().get();

--- a/src/main/java/com/openlattice/mail/utils/TemplateUtils.java
+++ b/src/main/java/com/openlattice/mail/utils/TemplateUtils.java
@@ -31,9 +31,7 @@ import com.samskivert.mustache.Mustache;
 public final class TemplateUtils {
 
     public static final Mustache.Compiler DEFAULT_TEMPLATE_COMPILER = Mustache.compiler()
-            .withLoader( templateResourcePath -> {
-                return new StringReader( loadTemplate( templateResourcePath ) );
-            } );
+            .withLoader( templateResourcePath -> new StringReader( loadTemplate( templateResourcePath ) ) );
 
     private TemplateUtils() {}
 

--- a/src/test/java/com/openlattice/mail/services/MailServiceTest.java
+++ b/src/test/java/com/openlattice/mail/services/MailServiceTest.java
@@ -22,6 +22,7 @@ package com.openlattice.mail.services;
 
 import com.openlattice.mail.templates.EmailTemplate;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -37,7 +38,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.openlattice.mail.RenderableEmailRequest;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.hazelcast.core.IQueue;
 
@@ -57,14 +57,14 @@ public class MailServiceTest extends GreenMailTest {
         RenderableEmailRequest emailRequest = new RenderableEmailRequest(
                 Optional.of( EmailTemplate.getCourierEmailAddress() ),
                 toAddresses,
-                Optional.absent(),
-                Optional.absent(),
+                Optional.empty(),
+                Optional.empty(),
                 EmailTemplate.SERVICE_OUTAGE.getPath(),
                 Optional.of( EmailTemplate.SERVICE_OUTAGE.getSubject() ),
                 Optional.of( ImmutableMap
                         .of( "name", "Master Chief", "avatar-path", "the path", "registration-url", "test" ) ),
-                Optional.absent(),
-                Optional.absent() );
+                Optional.empty(),
+                Optional.empty() );
 
         CountDownLatch latch = new CountDownLatch( 1 );
         Lock lock = new ReentrantLock();


### PR DESCRIPTION
This PR:
- Fixes a bunch of mechanical warnings
- Removing unused imports
- Removing unnecessary boxing/unboxing
- Uses singletonList for one-element lists
- Uses Java classes instead of Guava for functional constructs
- Fixes compiler warnings for upgrading from Java 5 through Java 8